### PR TITLE
Add instructions for examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,8 @@ Many examples are provided on the `examples/` folder.
 
     $ npm run dev
 
+Open `http://localhost:8080/examples/` after starting up the server to check out the examples.
+
 ##### Development auto-watch unit tests (without coverage)
 
     $ karma start


### PR DESCRIPTION
Took me a moment to figure out why tests weren't working... Turns out if you open `localhost:8080/examples` without the trailing slash, it won't work :(. 