### PR TITLE
Add base to examples html

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -6,6 +6,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <base href="/examples/">
     <title>Scrollable Demos</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, user-scalable=0">


### PR DESCRIPTION
Allows you to open the examples html with or without the trailing slash