### PR TITLE
removes equality in inViewport function

### DIFF
--- a/src/scroller-events.js
+++ b/src/scroller-events.js
@@ -40,10 +40,10 @@ function ScrollerEvents(domNode, handler, config) {
 }
 
 function inViewport (touch) {
-  return touch.pageX >= 0 &&
-         touch.pageX <= window.innerWidth,
-         touch.pageY >= 0 &&
-         touch.pageY <= window.innerHeight;
+  return touch.pageX > 0 &&
+         touch.pageX < window.innerWidth,
+         touch.pageY > 0 &&
+         touch.pageY < window.innerHeight;
 }
 
 var members = {


### PR DESCRIPTION
By removing equality, it removes the edge case where inViewport() returned true when there is a touch at the border of the viewport. 